### PR TITLE
feat: add support for AWS IAM Identity Center

### DIFF
--- a/cdk-multi-profile-plugin/src/ini-file-credential-provider-source.ts
+++ b/cdk-multi-profile-plugin/src/ini-file-credential-provider-source.ts
@@ -50,9 +50,10 @@ export class IniFileCredentialProviderSource
     if (!credentials) {
       if (this.profileConfig.isSSOProfile(profile)) {
         const ssoProfile = this.profileConfig.getProfile(profile);
-        const ssoLogin = this.ssoLoginCache.getCachedLogin(ssoProfile);
+        const ssoSettings = this.profileConfig.getSSOSettings(profile);
+        const ssoLogin = this.ssoLoginCache.getCachedLogin(ssoSettings);
 
-        const sso = new SSO({ region: ssoProfile.sso_region });
+        const sso = new SSO({ region: ssoSettings.sso_region });
 
         const { roleCredentials } = await sso
           .getRoleCredentials({

--- a/cdk-multi-profile-plugin/src/profile-config.ts
+++ b/cdk-multi-profile-plugin/src/profile-config.ts
@@ -20,11 +20,28 @@ export class ProfileConfig {
     return this.config[`profile ${profile}`];
   }
 
+  public getSSOSession(ssoSession: string): Record<string, string> {
+    return this.config[`sso-session ${ssoSession}`];
+  }
+
+  public getSSOSettings(profile: string): Record<string, string> {
+    if (!this.isSSOProfile(profile)) return {};
+
+    const config = this.getProfile(profile);
+    let ssoConfig: Record<string, string> = {};
+    if (config?.sso_session) {
+      ssoConfig = this.getSSOSession(config.sso_session);
+    }
+    const ssoSettings = {
+      sso_start_url: config?.sso_start_url ?? ssoConfig?.sso_start_url,
+      sso_region: config?.sso_region ?? ssoConfig?.sso_region,
+    };
+    return ssoSettings;
+  }
+
   public isSSOProfile(profile: string): boolean {
     const config = this.getProfile(profile);
 
-    if (config?.sso_start_url) return true;
-
-    return false;
+    return Boolean(config?.sso_start_url || config?.sso_session);
   }
 }


### PR DESCRIPTION
AWS CLI 2.9.x changed SSO configuration to allow automatic authentication refresh for AWS IAM Identity Center.

For details see: https://docs.aws.amazon.com/cli/latest/userguide/sso-configure-profile-token.html